### PR TITLE
Add catalog-info.yaml and repoint CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# See go/codeowners - automatically generated for confluentinc/cp-helm-charts:
-*	@confluentinc/cluster-management
+# Default owners for all files in this repo
+* @appfolio/platform-data-engineering

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: cp-helm-charts
+  description: "Fork of confluentinc/cp-helm-charts: Helm charts for deploying Confluent Platform services on Kubernetes"
+spec:
+  type: provisioner
+  lifecycle: stable
+  owner: CODEOWNERS


### PR DESCRIPTION
Repoints `.github/CODEOWNERS` from `@confluentinc/cluster-management` to `@appfolio/platform-data-engineering`, and adds `catalog-info.yaml` for the Developer Portal.

The existing entry was inherited from the upstream fork and references a team in the `confluentinc` org, so it does not resolve for a repo in `appfolio` — ownership routing is not working today.

Confirmed still in use by Brandon Stanley; assigned to platform-data-engineering.

Part of the repo ownership initiative: https://docs.google.com/spreadsheets/d/1sd6gorLtYuBb3W4JWK1R_K-PnSTmbTJoH27SQG1_8gU